### PR TITLE
Fixed section 0 instruction typos, "or.v" to "not.v" & extra k in conditional $display block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.vcd
 a.out
 obj_dir
+0-tools/and_not_testbench

--- a/0-tools/readme.md
+++ b/0-tools/readme.md
@@ -197,7 +197,7 @@ main phases:
     command continuation:
     ```bash
     $ iverilog -Wall -g 2012 -s and_not_testbench -o and_not_testbench \
-         and_gate.v or_gate.v and_not_testbench.v 
+         and_gate.v not_gate.v and_not_testbench.v 
     ```
 
     This command compiles the Verilog modules into a simulation
@@ -365,12 +365,12 @@ during simulation, including the values of pre-determined signals.
     they print. Replace all four existing `$display` statements with:
     ```Verilog
     if ( d != ~(a&b) ) begin
-        $display("Error : a=%d, b=%d, d=%d,  expected=%d", a, b, dk, ~(a&b));
+        $display("Error : a=%d, b=%d, d=%d,  expected=%d", a, b, d, ~(a&b));
     end
     ```
     This should ensure that the printing only happens when `d` has the wrong value.
 
-5.  Compile and simulate the test-bench. Given the `and` and `nno` gates are
+5.  Compile and simulate the test-bench. Given the `and` and `not` gates are
     correct, no output should be printed.
 
 6.  Break the `and` gate again, and then re-simulate. You should find that


### PR DESCRIPTION
1. The command for the first compilation under section "Compile and run a Verilog simulation"  should be referring to the "not.v" file instead of the non-existent "or.v" file. 
2. The 5th instruction under the "Add print statements to a test-bench" section has an extra k within the Verilog code. 

